### PR TITLE
Do not log long messages

### DIFF
--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -22,6 +22,7 @@ use log::{debug, error, info, warn};
 use serde_json::Value;
 use sp_core::Pair;
 use sp_runtime::MultiSignature;
+use support::traits::Len;
 use ws::{CloseCode, Error, Handler, Handshake, Message, Result as WsResult, Sender};
 
 use crate::std::rpc::RpcClientError;
@@ -145,10 +146,7 @@ fn format_message(msg: &Message) -> String {
     match (msg.as_text(), msg) {
         (Ok(text), _) if text.len() <= MAX_MESSAGE_LEN => text.to_string(),
         (Ok(text), _)  => format!("{}...", &text[..MAX_MESSAGE_LEN]),
-        (_, Message::Binary(bin)) if bin.len() <= MAX_MESSAGE_LEN => format!("Binary content: {:?}", bin),
-        (_, Message::Binary(bin)) => {
-            format!("Binary content: {:?}...", &bin[..MAX_MESSAGE_LEN])
-        }
+        (_, Message::Binary(bin)) => format!("Binary Data<length={}>", bin.len()),
         _ => unreachable!("Only `Message::Binary` can fail `.as_text()`.")
     }
 }
@@ -159,7 +157,7 @@ pub fn on_get_request_msg(msg: Message, out: Sender, result: ThreadOut<String>) 
 
     info!("Got get_request_msg {}", format_message(&msg));
     let result_str = serde_json::from_str(msg.as_text()?)
-        .map(|v: Value| v["result"].to_string())
+        .map(|v: serde_json::Value| v["result"].to_string())
         .map_err(|e| Box::new(RpcClientError::Serde(e)))?;
 
     result
@@ -169,7 +167,7 @@ pub fn on_get_request_msg(msg: Message, out: Sender, result: ThreadOut<String>) 
 
 pub fn on_subscription_msg(msg: Message, out: Sender, result: ThreadOut<String>) -> WsResult<()> {
     info!("got on_subscription_msg {}", format_message(&msg));
-    let value: Value =
+    let value: serde_json::Value =
         serde_json::from_str(msg.as_text()?).map_err(|e| Box::new(RpcClientError::Serde(e)))?;
 
     match value["id"].as_str() {
@@ -315,7 +313,7 @@ fn end_process(out: Sender, result: ThreadOut<String>, value: Option<String>) ->
 }
 
 fn parse_status(msg: &str) -> RpcResult<(XtStatus, Option<String>)> {
-    let value: Value = serde_json::from_str(msg)?;
+    let value: serde_json::Value = serde_json::from_str(msg)?;
 
     if value["error"].as_object().is_some() {
         return Err(into_extrinsic_err(&value));
@@ -374,7 +372,7 @@ fn into_extrinsic_err(resp_with_err: &Value) -> RpcClientError {
 }
 
 fn result_from_json_response(resp: &str) -> RpcResult<String> {
-    let value: Value = serde_json::from_str(resp)?;
+    let value: serde_json::Value = serde_json::from_str(resp)?;
 
     let resp = value["result"]
         .as_str()

--- a/src/std/rpc/ws_client/mod.rs
+++ b/src/std/rpc/ws_client/mod.rs
@@ -143,11 +143,10 @@ where
 const MAX_MESSAGE_LEN: usize = 1024;
 
 fn format_message(msg: &Message) -> String {
-    match (msg.as_text(), msg) {
-        (Ok(text), _) if text.len() <= MAX_MESSAGE_LEN => text.to_string(),
-        (Ok(text), _)  => format!("{}...", &text[..MAX_MESSAGE_LEN]),
-        (_, Message::Binary(bin)) => format!("Binary Data<length={}>", bin.len()),
-        _ => unreachable!("Only `Message::Binary` can fail `.as_text()`.")
+    match msg.as_text() {
+        Ok(text) if text.len() <= MAX_MESSAGE_LEN => text.to_string(),
+        Ok(text) => format!("{}...", &text[..MAX_MESSAGE_LEN]),
+        _ => format!("Binary Data<length={}>", msg.len()),
     }
 }
 


### PR DESCRIPTION
This PR provides custom formatting for `Message` type. The direct and most important consequence is that we will not see veeeeery long log lines containing the whole metadata (including runtime code). They will be shortened to:
```
[2022-05-18T11:12:21Z INFO  substrate_api_client::std::rpc::ws_client] Got get_request_msg {"jsonrpc":"2.0",
"result":"0x6d6574610e6903000c1c73705f636f72651863727970746f2c4163636f756e7449643332000004000401
205b75383b2033325d0000040000032000000008000800000503000c08306672616d655f73797374656d2c4163636f756e74496e
666f0814496e64657801102c4163636f756e74446174610114001401146e6f6e6365100114496e646578000124636f6e73756d657
273100120526566436f756e7400012470726f766964657273100120526566436f756e7400012c73756666696369656e747310012
0526566436f756e740001106461746114012c4163636f756e7444617461000010000005050014083c70616c6c65745f62616c616e
6365732c4163636f756e7444617461041c42616c616e63650118001001106672656518011c42616c616e63650001207265736572
76656418011c42616c616e636500012c6d6973635f66726f7a656e18011c42616c616e63650001286665655f66726f7a656e18011
c42616c616e636500001800000507001c0c346672616d655f737570706f72741c776569676874734050657244697370617463684
36c6173730404540120000c01186e6f726d616c2001045400012c6f7065726174696f6e616c200104540001246d616e6461746f72
7920010454000020000005060024083c7072696d69746976655f74797065731048323536000...
```